### PR TITLE
Make the `builder` module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ mod projstr;
 
 pub mod parser;
 
-pub use builder::Builder;
+pub use builder::{Builder, Node};
 pub use projstr::Formatter;
 
 use errors::Result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@
 //! );
 //! ```
 //!
-mod builder;
 mod consts;
 mod errors;
 mod methods;
@@ -50,8 +49,9 @@ mod parse;
 mod projstr;
 
 pub mod parser;
+pub mod builder;
 
-pub use builder::{Builder, Node};
+pub use builder::Builder;
 pub use projstr::Formatter;
 
 use errors::Result;


### PR DESCRIPTION
Make the `Node` enum public, so that the result of `Builder::parse` can be matched against.