### PR TITLE
Support parsing the authority code of a geogcs node

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -236,6 +236,7 @@ impl Builder {
         let mut name = None;
         let mut datum = None;
         let mut unit = None;
+        let mut authority = None;
 
         for (i, a) in attrs.enumerate() {
             match a {
@@ -243,6 +244,7 @@ impl Builder {
                 Attribute::Keyword(_, n) => match n {
                     Node::DATUM(d) => datum = Some(d),
                     Node::UNIT(u) => unit = Some(u),
+                    Node::AUTHORITY(a) => authority = Some(a),
                     _ => (),
                 },
                 _ => (),
@@ -265,6 +267,7 @@ impl Builder {
             name: name.unwrap_or(""),
             datum: datum.ok_or(Error::Wkt("Missing DATUM for geodetic crs".into()))?,
             unit,
+            authority,
         })
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,6 +6,7 @@ pub struct Geogcs<'a> {
     pub name: &'a str,
     pub datum: Datum<'a>,
     pub unit: Option<Unit<'a>>,
+    pub authority: Option<Authority<'a>>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -30,6 +30,19 @@ pub mod fixtures {
         r#"PARAMETER["false_easting",200000],PARAMETER["false_northing",750000],"#,
         r#"AUTHORITY["EPSG","26986"],AXIS["X",EAST],AXIS["Y",NORTH]]"#,
     );
+
+    pub const WKT_GEOGCS_WGS84: &str = r#"
+        GEOGCS["WGS 84",
+            DATUM["WGS_1984",
+                SPHEROID["WGS 84",6378137,298.257223563,
+                    AUTHORITY["EPSG","7030"]],
+                AUTHORITY["EPSG","6326"]],
+            PRIMEM["Greenwich",0,
+                AUTHORITY["EPSG","8901"]],
+            UNIT["degree",0.0174532925199433,
+                AUTHORITY["EPSG","9122"]],
+            AUTHORITY["EPSG","4326"]
+        ]"#;
 }
 
 #[test]
@@ -129,6 +142,26 @@ fn build_wgs84() {
 }
 
 #[test]
+fn parse_wgs84_wkt() {
+    setup();
+    let r = Builder::new()
+        .parse(fixtures::WKT_GEOGCS_WGS84)
+        .expect("Failed to parse WGS84 WKT");
+    if let Node::GEOGCRS(geogcrs) = &r {
+        assert_eq!(geogcrs.name, "WGS 84");
+        assert_eq!(
+            geogcrs.authority,
+            Some(Authority {
+                name: "EPSG",
+                code: "4326",
+            })
+        );
+    } else {
+        panic!("Expected GEOGCRS node");
+    }
+}
+
+#[test]
 fn build_nad83() {
     setup();
     let r = Builder::new().parse(fixtures::WKT_PROJCS_NAD83).unwrap();
@@ -154,6 +187,7 @@ fn build_nad83() {
                     factor: 0.01745329251994328,
                     unit_type: UnitType::Angular,
                 }),
+                authority: None,
             },
             projection: Projection {
                 name: "Unknown",


### PR DESCRIPTION
I needed to obtain the authority code of the WKT string for a geogcs node.  This was not parsed yet so I added it.