### PR TITLE
Fix the repository URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ readme = "./README.md"
 keywords = ["gis", "proj", "projection", "geography", "geospatial"]
 authors = ["David Marteau <dmarteau@3liz.com>"]
 license = "MIT OR Apache-2.0"
-homepage = "https://github.com/3liz/proj4wkt/"
-repository = "https://github.com/3liz/proj4wkt/"
+homepage = "https://github.com/3liz/proj4wkt-rs/"
+repository = "https://github.com/3liz/proj4wkt-rs/"
 documentation = "https://docs.rs/proj4wkt/"
 exclude = [
     "js/*",


### PR DESCRIPTION
I found the repository link on docs.rs returns 404 error. It seems the URLs are missing `-rs` suffix.